### PR TITLE
fix(Reminder): no notifications unless someone is working

### DIFF
--- a/lib/review_bot/reminder.rb
+++ b/lib/review_bot/reminder.rb
@@ -74,7 +74,7 @@ module ReviewBot
           pull.reviewers.include?(reviewer['github'])
         end
 
-        next if suggested_reviewers.empty?
+        next if suggested_reviewers.select(&:work_hour?).empty?
 
         Notification.new(
           pull_request: pull,


### PR DESCRIPTION
If it's not a work hour for _any_ of the suggested reviewers, don't bother sending a notification

Fixes #14