### PR TITLE
change(PullRequest): only consider reviews

### DIFF
--- a/lib/review_bot.rb
+++ b/lib/review_bot.rb
@@ -9,6 +9,7 @@ require 'pry'
 
 require_relative 'review_bot/hour_of_day'
 require_relative 'review_bot/pull_request'
+require_relative 'review_bot/pull_request_review'
 require_relative 'review_bot/extensions'
 require_relative 'review_bot/reviewer'
 require_relative 'review_bot/reminder'

--- a/lib/review_bot/pull_request_review.rb
+++ b/lib/review_bot/pull_request_review.rb
@@ -1,0 +1,24 @@
+module ReviewBot
+  class PullRequestReview < Hashie::Mash
+    def self.for_pull_request(pull_request)
+      # github_api doesn't support this yet
+      conn = Faraday.new(
+        url: 'https://api.github.com',
+        headers: { Accept: 'application/vnd.github.black-cat-preview+json' }
+      )
+      reviews_json = conn.get(
+        "/repos/#{pull_request.repo_owner}/#{pull_request.repo_name}/pulls/#{pull_request.number}/reviews?access_token=#{ENV['GH_AUTH_TOKEN']}"
+      ).body
+
+      JSON.parse(reviews_json).map { |r| new r }
+    end
+
+    def approved?
+      state == 'APPROVED'
+    end
+
+    def created_at
+      submitted_at
+    end
+  end
+end


### PR DESCRIPTION
Stop considering comments and labels when trying to understand if a pull request is in review and if it has been approved. Use reviews only

Fixes #7 