### PR TITLE
fix(Reminder): work even if there are no reviewers

### DIFF
--- a/lib/review_bot/reminder.rb
+++ b/lib/review_bot/reminder.rb
@@ -66,7 +66,7 @@ module ReviewBot
 
         person_hours_since_last_touch = potential_reviewers.map do |reviewer|
           reviewer.work_hours_between(pull.last_touched_at, Time.now.utc)
-        end.reduce(:+)
+        end.reduce(0, :+)
 
         next if person_hours_since_last_touch < app_config['hours_to_review']
 


### PR DESCRIPTION
Handle a case where there are no available reviewers, and turn that
into 0 work hours since the PR was opened